### PR TITLE
feat: add API passthrough command for direct API access

### DIFF
--- a/internal/cmd/api.go
+++ b/internal/cmd/api.go
@@ -119,7 +119,11 @@ For example, use "/team" for https://api.clickup.com/api/v2/team`,
 			fmt.Fprintf(os.Stderr, "Request failed: %v\n", err)
 			os.Exit(1)
 		}
-		defer resp.Body.Close()
+		defer func() {
+			if err := resp.Body.Close(); err != nil {
+				fmt.Fprintf(os.Stderr, "Error closing response body: %v\n", err)
+			}
+		}()
 
 		// Read response
 		respBody, err := io.ReadAll(resp.Body)
@@ -141,7 +145,9 @@ For example, use "/team" for https://api.clickup.com/api/v2/team`,
 					fmt.Fprintf(os.Stderr, "Error: %s\n", msg)
 				} else {
 					// Output the full error response
-					output.Format("json", errResp)
+					if err := output.Format("json", errResp); err != nil {
+						fmt.Fprintf(os.Stderr, "Error formatting response: %v\n", err)
+					}
 				}
 			} else {
 				fmt.Fprintf(os.Stderr, "Response: %s\n", string(respBody))

--- a/internal/cmd/api.go
+++ b/internal/cmd/api.go
@@ -1,0 +1,174 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/tim/cu/internal/auth"
+	"github.com/tim/cu/internal/output"
+)
+
+var (
+	apiMethod string
+	apiData   string
+	apiHeaders []string
+)
+
+var apiCmd = &cobra.Command{
+	Use:   "api <endpoint>",
+	Short: "Make direct API requests to ClickUp",
+	Long: `Make direct API requests to the ClickUp API.
+
+This command provides direct access to any ClickUp API endpoint,
+useful for operations not yet implemented in the CLI or for
+advanced use cases.
+
+Examples:
+  # Get all workspaces
+  cu api /team
+
+  # Get a specific task
+  cu api /task/abc123
+
+  # Create a new task (with data)
+  cu api /list/def456/task -X POST -d '{"name": "New Task"}'
+
+  # Update task with PATCH
+  cu api /task/abc123 -X PATCH -d '{"name": "Updated Name"}'
+
+  # Delete a task
+  cu api /task/abc123 -X DELETE
+
+  # Get tasks with query parameters
+  cu api "/list/def456/task?archived=false&page=0"
+
+  # Get custom fields for a list
+  cu api /list/def456/field
+
+  # Pass custom headers
+  cu api /team -H "X-Custom-Header: value"
+
+The endpoint should be the path after https://api.clickup.com/api/v2/
+For example, use "/team" for https://api.clickup.com/api/v2/team`,
+	Args: cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		endpoint := args[0]
+		
+		// Ensure endpoint starts with /
+		if !strings.HasPrefix(endpoint, "/") {
+			endpoint = "/" + endpoint
+		}
+
+		// Get authentication token
+		authMgr := auth.NewManager()
+		token, err := authMgr.GetCurrentToken()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Not authenticated. Run 'cu auth login' first.\n")
+			os.Exit(1)
+		}
+
+		// Build full URL
+		baseURL := "https://api.clickup.com/api/v2"
+		fullURL := baseURL + endpoint
+
+		// Prepare request body if data provided
+		var body io.Reader
+		if apiData != "" {
+			// Validate JSON if content-type suggests it
+			if strings.Contains(apiData, "{") || strings.Contains(apiData, "[") {
+				var js json.RawMessage
+				if err := json.Unmarshal([]byte(apiData), &js); err != nil {
+					fmt.Fprintf(os.Stderr, "Warning: data does not appear to be valid JSON: %v\n", err)
+				}
+			}
+			body = bytes.NewBufferString(apiData)
+		}
+
+		// Create request
+		req, err := http.NewRequest(apiMethod, fullURL, body)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Failed to create request: %v\n", err)
+			os.Exit(1)
+		}
+
+		// Set headers
+		req.Header.Set("Authorization", token.Value)
+		req.Header.Set("Content-Type", "application/json")
+		
+		// Add custom headers
+		for _, header := range apiHeaders {
+			parts := strings.SplitN(header, ":", 2)
+			if len(parts) == 2 {
+				req.Header.Set(strings.TrimSpace(parts[0]), strings.TrimSpace(parts[1]))
+			}
+		}
+
+		// Make request
+		client := &http.Client{
+			Timeout: 30 * time.Second,
+		}
+		
+		resp, err := client.Do(req)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Request failed: %v\n", err)
+			os.Exit(1)
+		}
+		defer resp.Body.Close()
+
+		// Read response
+		respBody, err := io.ReadAll(resp.Body)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Failed to read response: %v\n", err)
+			os.Exit(1)
+		}
+
+		// Check for non-2xx status codes
+		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+			fmt.Fprintf(os.Stderr, "API request failed with status %d: %s\n", resp.StatusCode, resp.Status)
+			
+			// Try to parse error response
+			var errResp map[string]interface{}
+			if err := json.Unmarshal(respBody, &errResp); err == nil {
+				if msg, ok := errResp["err"].(string); ok {
+					fmt.Fprintf(os.Stderr, "Error: %s\n", msg)
+				} else if msg, ok := errResp["error"].(string); ok {
+					fmt.Fprintf(os.Stderr, "Error: %s\n", msg)
+				} else {
+					// Output the full error response
+					output.Format("json", errResp)
+				}
+			} else {
+				fmt.Fprintf(os.Stderr, "Response: %s\n", string(respBody))
+			}
+			os.Exit(1)
+		}
+
+		// Parse response as JSON
+		var result interface{}
+		if err := json.Unmarshal(respBody, &result); err != nil {
+			// If not JSON, output as string
+			fmt.Println(string(respBody))
+			return
+		}
+
+		// Format output
+		format := cmd.Flag("output").Value.String()
+		if err := output.Format(format, result); err != nil {
+			fmt.Fprintf(os.Stderr, "Failed to format output: %v\n", err)
+			os.Exit(1)
+		}
+	},
+}
+
+func init() {
+	apiCmd.Flags().StringVarP(&apiMethod, "method", "X", "GET", "HTTP method (GET, POST, PUT, PATCH, DELETE)")
+	apiCmd.Flags().StringVarP(&apiData, "data", "d", "", "Request body data (JSON)")
+	apiCmd.Flags().StringArrayVarP(&apiHeaders, "header", "H", []string{}, "Custom headers (format: 'Header: value')")
+}

--- a/internal/cmd/api.go
+++ b/internal/cmd/api.go
@@ -67,8 +67,7 @@ For example, use "/team" for https://api.clickup.com/api/v2/team`,
 		}
 
 		// Get authentication token
-		authMgr := auth.NewManager()
-		token, err := authMgr.GetCurrentToken()
+		token, err := getAuthToken()
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Not authenticated. Run 'cu auth login' first.\n")
 			os.Exit(1)
@@ -165,6 +164,12 @@ For example, use "/team" for https://api.clickup.com/api/v2/team`,
 			os.Exit(1)
 		}
 	},
+}
+
+// getAuthToken is a variable to make auth testable
+var getAuthToken = func() (*auth.Token, error) {
+	authMgr := auth.NewManager()
+	return authMgr.GetCurrentToken()
 }
 
 func init() {

--- a/internal/cmd/api_test.go
+++ b/internal/cmd/api_test.go
@@ -29,8 +29,7 @@ func TestAPICommand(t *testing.T) {
 	methodFlag := cmd.Flag("method")
 	if methodFlag == nil {
 		t.Error("method flag should exist")
-	}
-	if methodFlag.DefValue != "GET" {
+	} else if methodFlag.DefValue != "GET" {
 		t.Errorf("method flag default should be GET, got %s", methodFlag.DefValue)
 	}
 

--- a/internal/cmd/api_test.go
+++ b/internal/cmd/api_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -11,10 +12,26 @@ func TestAPICommand(t *testing.T) {
 		t.Fatal("apiCmd should not be nil")
 	}
 
+	// Check command metadata
+	if cmd.Use != "api <endpoint>" {
+		t.Errorf("Expected Use 'api <endpoint>', got %s", cmd.Use)
+	}
+
+	if cmd.Short == "" {
+		t.Error("Short description should not be empty")
+	}
+
+	if cmd.Long == "" {
+		t.Error("Long description should not be empty")
+	}
+
 	// Check flags exist
 	methodFlag := cmd.Flag("method")
 	if methodFlag == nil {
 		t.Error("method flag should exist")
+	}
+	if methodFlag.DefValue != "GET" {
+		t.Errorf("method flag default should be GET, got %s", methodFlag.DefValue)
 	}
 
 	dataFlag := cmd.Flag("data")
@@ -25,5 +42,92 @@ func TestAPICommand(t *testing.T) {
 	headerFlag := cmd.Flag("header")
 	if headerFlag == nil {
 		t.Error("header flag should exist")
+	}
+}
+
+func TestEndpointNormalization(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "with leading slash",
+			input:    "/team",
+			expected: "/team",
+		},
+		{
+			name:     "without leading slash",
+			input:    "team",
+			expected: "/team",
+		},
+		{
+			name:     "with query params",
+			input:    "/list/123?archived=false",
+			expected: "/list/123?archived=false",
+		},
+	}
+
+	for _, tt := range tests {  
+		t.Run(tt.name, func(t *testing.T) {
+			// This tests the logic that should add leading slash
+			result := tt.input
+			if !strings.HasPrefix(result, "/") {
+				result = "/" + result
+			}
+			if result != tt.expected {
+				t.Errorf("Expected %s, got %s", tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestHeaderParsing(t *testing.T) {
+	tests := []struct {
+		name           string
+		headers        []string
+		expectedKey    string
+		expectedValue  string
+		shouldParse    bool
+	}{
+		{
+			name:          "valid header",
+			headers:       []string{"X-Custom: value"},
+			expectedKey:   "X-Custom",
+			expectedValue: "value",
+			shouldParse:   true,
+		},
+		{
+			name:          "header with spaces",
+			headers:       []string{"X-Custom:    value with spaces   "},
+			expectedKey:   "X-Custom",
+			expectedValue: "value with spaces",
+			shouldParse:   true,
+		},
+		{
+			name:        "invalid header",
+			headers:     []string{"InvalidHeader"},
+			shouldParse: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for _, header := range tt.headers {
+				parts := strings.SplitN(header, ":", 2)
+				if tt.shouldParse && len(parts) != 2 {
+					t.Errorf("Expected header to parse into 2 parts")
+				} else if tt.shouldParse {
+					key := strings.TrimSpace(parts[0])
+					value := strings.TrimSpace(parts[1])
+					if key != tt.expectedKey {
+						t.Errorf("Expected key %s, got %s", tt.expectedKey, key)
+					}
+					if value != tt.expectedValue {
+						t.Errorf("Expected value %s, got %s", tt.expectedValue, value)
+					}
+				}
+			}
+		})
 	}
 }

--- a/internal/cmd/api_test.go
+++ b/internal/cmd/api_test.go
@@ -1,0 +1,29 @@
+package cmd
+
+import (
+	"testing"
+)
+
+func TestAPICommand(t *testing.T) {
+	// Just verify the command exists and can be created
+	cmd := apiCmd
+	if cmd == nil {
+		t.Fatal("apiCmd should not be nil")
+	}
+
+	// Check flags exist
+	methodFlag := cmd.Flag("method")
+	if methodFlag == nil {
+		t.Error("method flag should exist")
+	}
+
+	dataFlag := cmd.Flag("data")
+	if dataFlag == nil {
+		t.Error("data flag should exist")
+	}
+
+	headerFlag := cmd.Flag("header")
+	if headerFlag == nil {
+		t.Error("header flag should exist")
+	}
+}

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -63,6 +63,7 @@ func init() {
 
 	// Add subcommands
 	rootCmd.AddCommand(authCmd)
+	rootCmd.AddCommand(apiCmd)
 	rootCmd.AddCommand(configCmd)
 	rootCmd.AddCommand(completionCmd)
 	rootCmd.AddCommand(versionCmd)


### PR DESCRIPTION
## Summary
- Implement `cu api` command for direct ClickUp API access
- Enable advanced users to access any API endpoint
- Support all HTTP methods and custom headers

## Features
- **Direct API access**: Call any ClickUp API endpoint with `cu api <endpoint>`
- **All HTTP methods**: Support GET, POST, PUT, PATCH, DELETE via `-X` flag
- **Request body**: Send JSON data with `-d` flag
- **Custom headers**: Add headers with `-H` flag
- **Auto formatting**: Results automatically formatted based on `-o` flag
- **Authentication**: Uses existing cu authentication

## Examples
```bash
# Get all workspaces
cu api /team

# Get a specific task
cu api /task/abc123

# Create a new task
cu api /list/def456/task -X POST -d '{"name": "New Task"}'

# Update task with PATCH
cu api /task/abc123 -X PATCH -d '{"name": "Updated Name"}'

# Get custom fields for a list
cu api /list/def456/field

# Query with parameters
cu api "/list/def456/task?archived=false&page=0"
```

## Test plan
- [ ] Test GET requests to various endpoints
- [ ] Test POST request to create a resource
- [ ] Test PATCH/PUT to update resources
- [ ] Test DELETE to remove a resource
- [ ] Verify authentication is required
- [ ] Test custom headers work correctly
- [ ] Verify JSON validation warnings

🤖 Generated with [Claude Code](https://claude.ai/code)