### PR TITLE
Fix mkdocstrings-go package installation

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -34,7 +34,8 @@ jobs:
       - name: Install MkDocs and theme
         run: |
           pip install mkdocs-material
-          pip install mkdocstrings[go]
+          pip install mkdocstrings
+          pip install mkdocstrings-go
           
       - name: Build documentation
         run: mkdocs build --site-dir _site


### PR DESCRIPTION
## Summary
- Fixed the GitHub Actions workflow that was failing to build documentation
- Corrected the package installation from `mkdocstrings[go]` to separate `mkdocstrings` and `mkdocstrings-go` packages

## Test plan
- [ ] GitHub Actions workflow should complete successfully
- [ ] Documentation site should build without ModuleNotFoundError

🤖 Generated with [Claude Code](https://claude.ai/code)