### PR TITLE
Add documentation site badge and links to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # cu - ClickUp CLI
 
 [![CI](https://github.com/timimsms/cu/actions/workflows/ci.yml/badge.svg)](https://github.com/timimsms/cu/actions/workflows/ci.yml)
+[![Documentation](https://img.shields.io/badge/docs-timimsms.github.io%2Fcu-blue)](https://timimsms.github.io/cu/)
 
 A GitHub CLI-inspired command-line interface for ClickUp.
 
@@ -122,10 +123,13 @@ cu api "/list/abc123/task?archived=false"
 
 ## Documentation
 
-- [Installation Guide](docs/installation.md)
-- [Configuration](docs/configuration.md)
-- [Authentication](docs/authentication.md)
-- [Command Reference](docs/commands/)
+Full documentation is available at [https://timimsms.github.io/cu/](https://timimsms.github.io/cu/)
+
+### Quick Links
+- [Command Reference](https://timimsms.github.io/cu/commands/cu/)
+- [Task Management](https://timimsms.github.io/cu/commands/cu_task/)
+- [Configuration](https://timimsms.github.io/cu/commands/cu_config/)
+- [Authentication](https://timimsms.github.io/cu/commands/cu_auth/)
 
 ## Development
 


### PR DESCRIPTION
## Summary
- Added a documentation badge to the README
- Updated documentation section with link to the live GitHub Pages site
- Added quick links to key documentation pages

## Changes
- Added documentation badge next to CI badge
- Replaced broken local documentation links with links to the live site at https://timimsms.github.io/cu/
- Added quick links section for easy navigation to common documentation pages

## Test plan
- [x] Documentation badge displays correctly
- [x] All links point to the correct pages on the live site
- [x] Links work after deployment

🤖 Generated with [Claude Code](https://claude.ai/code)