### PR TITLE
docs: refresh site and README for post-v0.1.0 accuracy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,7 +130,7 @@ jobs:
         
     - name: Install MkDocs and theme
       run: |
-        pip install mkdocs-material
+        pip install 'mkdocs-material==9.*'
         
     - name: Test documentation build
       run: mkdocs build --strict --site-dir _test_site

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
     paths:
-      - 'docs/**'
+      - 'docs/site/**'
       - 'mkdocs.yml'
       - '.github/workflows/deploy-docs.yml'
   workflow_dispatch:
@@ -33,7 +33,7 @@ jobs:
           
       - name: Install MkDocs and theme
         run: |
-          pip install mkdocs-material
+          pip install 'mkdocs-material==9.*'
           
       - name: Build documentation
         run: mkdocs build --strict --site-dir _site

--- a/README.md
+++ b/README.md
@@ -31,15 +31,17 @@ A GitHub CLI-inspired command-line interface for ClickUp.
 brew install timimsms/cu/cu
 ```
 
-Installs from the [timimsms/homebrew-cu](https://github.com/timimsms/homebrew-cu) tap. Available with the first tagged release.
+Installs the latest tagged release from the [timimsms/homebrew-cu](https://github.com/timimsms/homebrew-cu) tap.
 
 ### Go
 ```bash
 go install github.com/timimsms/cu/cmd/cu@latest
 ```
 
+Note: binaries installed via `go install` currently report `dev` from `cu version` ([#36](https://github.com/timimsms/cu/issues/36)); Homebrew and release downloads embed the real version.
+
 ### npm
-Planned as `@timimsms/cu` (not yet published).
+The package name `@timimsms/cu` is reserved on npm as a placeholder only — a functional package is not yet published. Use Homebrew, `go install`, or a release download instead.
 
 ### Direct Download
 Download the latest release from the [releases page](https://github.com/timimsms/cu/releases).

--- a/docs/site/authentication.md
+++ b/docs/site/authentication.md
@@ -36,7 +36,7 @@ Tokens are never written to disk in plaintext by `cu` — there is no plaintext 
 
 ## Headless Linux Caveat
 
-On headless Linux (servers, containers, CI), `cu` requires a running Secret Service implementation to store and read the token. There is currently no environment-variable fallback, so authentication will fail without one. A common workaround is to run a keyring daemon such as `gnome-keyring-daemon` with a D-Bus session.
+On headless Linux (servers, containers, CI), `cu` requires a running Secret Service implementation to store and read the token. There is currently no environment-variable fallback, so authentication will fail without one. A common workaround is to run a keyring daemon such as `gnome-keyring-daemon` with a D-Bus session. An environment-variable token fallback is planned — see [issue #26](https://github.com/timimsms/cu/issues/26).
 
 ## Revoking Access
 

--- a/docs/site/index.md
+++ b/docs/site/index.md
@@ -29,7 +29,7 @@ A GitHub CLI-inspired command-line interface for ClickUp.
 brew install timimsms/cu/cu
 ```
 
-Installs from the [timimsms/homebrew-cu](https://github.com/timimsms/homebrew-cu) tap. Available with the first tagged release.
+Installs the latest tagged release from the [timimsms/homebrew-cu](https://github.com/timimsms/homebrew-cu) tap.
 
 ### Go
 
@@ -37,9 +37,11 @@ Installs from the [timimsms/homebrew-cu](https://github.com/timimsms/homebrew-cu
 go install github.com/timimsms/cu/cmd/cu@latest
 ```
 
+Note: binaries installed via `go install` currently report `dev` from `cu version` ([#36](https://github.com/timimsms/cu/issues/36)); Homebrew and release downloads embed the real version.
+
 ### npm
 
-Planned as `@timimsms/cu` (not yet published).
+The package name `@timimsms/cu` is reserved on npm as a placeholder only — a functional package is not yet published. Use Homebrew, `go install`, or a release download instead.
 
 ### Direct Download
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -28,6 +28,7 @@ theme:
     - search.highlight
     - content.tabs.link
     - content.code.copy
+    - content.action.edit
 
 nav:
   - Home: index.md


### PR DESCRIPTION
Lands the verified accuracy fixes from the post-v0.1.0 documentation audits (live site + sources). Every claim was re-verified against the working tree before editing.

## Fixes

1. **Homebrew section: stale future tense** (README.md:34, docs/site/index.md:32)
   Audit evidence: live homepage and README still said "Available with the first tagged release." while `gh release view v0.1.0` shows the release published 2026-07-15 with 5 platform archives + checksums.txt and the tap live.
   Fix: "Installs the latest tagged release from the timimsms/homebrew-cu tap."

2. **npm section: placeholder status not conveyed** (README.md:42, docs/site/index.md:42)
   Audit evidence: `@timimsms/cu` exists on npm as a 0.0.1 placeholder (name reserved); "Planned as `@timimsms/cu` (not yet published)" could mislead readers who find it on npm.
   Fix: states the name is reserved as a placeholder only, functional package not yet published; still no install command advertised.

3. **go install "dev" version caveat** (README.md, docs/site/index.md, under the Go install block)
   Audit evidence: Makefile injects version via -ldflags only in make/goreleaser builds; a fresh `go build` from main reports `cu version dev` (open issue #36).
   Fix: one-line note linking #36.

4. **Auth page: env-fallback cross-reference** (docs/site/authentication.md:39)
   Audit evidence: "no environment-variable fallback" is accurate today (only os.Getenv in the tree is HOME) but reads as permanent; issue #26 (open) tracks the planned fallback.
   Fix: appended "An environment-variable token fallback is planned — see issue #26."

5. **Edit pencil never renders** (mkdocs.yml)
   Audit evidence: `edit_uri: edit/main/docs/site/` is set but theme.features lacked `content.action.edit`, so live HTML contains zero edit links (grep count 0). Verified locally: after adding the feature, the built index.html contains the edit link (grep count 1).
   Fix: added `content.action.edit` to theme.features.

6. **Deploy trigger broader than the published site** (.github/workflows/deploy-docs.yml)
   Audit evidence: paths included `docs/**` while docs_dir is `docs/site`; run 29550158962 was triggered by PR #39 whose only file was docs/design/context-layer.md (intentionally unpublished).
   Fix: narrowed to `docs/site/**` (mkdocs.yml and the workflow file remain triggers).

7. **mkdocs-material unpinned** (.github/workflows/deploy-docs.yml:36, .github/workflows/ci.yml:133)
   Audit evidence: `pip install mkdocs-material` with no constraint + `--strict` builds; Material's MkDocs 2.0 advisory banner warns of upcoming breaking changes.
   Fix: pinned to `'mkdocs-material==9.*'` in both workflows.

## Deliberately not included

- **Command-page regeneration**: rebuilt cu from main and ran `cu docs markdown`; all 45 regenerated pages are byte-identical to docs/site/commands/ except the cobra footer-date line (0 non-footer diff lines). The live audit's "content drift" claim did not reproduce; regenerating would be 45 files of footer-date churn for zero content value.
- Changelog/release page, README release badge, LICENSE copyright line — feature proposals / maintainer-preference items, left for the maintainer.

## Verification

- `mkdocs build --strict` in a scratch venv (mkdocs 1.6.1, mkdocs-material 9.x): exit 0, no warnings.
- Built HTML spot-checks: edit link present, new npm phrasing present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)