### PR TITLE
docs: add changelog/release surface, badges, and LICENSE attribution

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -8,6 +8,8 @@ on:
       - 'docs/site/**'
       - 'mkdocs.yml'
       - '.github/workflows/deploy-docs.yml'
+  release:
+    types: [published]
   workflow_dispatch:
 
 permissions:
@@ -34,7 +36,22 @@ jobs:
       - name: Install MkDocs and theme
         run: |
           pip install 'mkdocs-material==9.*'
-          
+
+      - name: Regenerate changelog from GitHub Releases
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          {
+            echo "# Changelog"
+            echo
+            echo "Release notes for \`cu\`. This page is regenerated from [GitHub Releases](https://github.com/timimsms/cu/releases) on every documentation deploy."
+            echo
+            gh api "repos/${GITHUB_REPOSITORY}/releases" --paginate \
+              --jq '.[] | select(.draft == false) | "## [\(.tag_name)](\(.html_url)) — \(.published_at[:10])\n\n" + ((.body // "") | gsub("\r";"") | sub("^## ClickUp CLI[^\n]*\n";"") | split("\n## Installation")[0] | gsub("\n## ";"\n### ") | gsub("\n### Changelog\n";"\n")) + "\n"' \
+              | sed -E 's/^\* [0-9a-f]{40}: /* /; s/ \([^()]+ <[^>]+>\)$//'
+          } | cat -s > docs/site/changelog.md
+          head -5 docs/site/changelog.md
+
       - name: Build documentation
         run: mkdocs build --strict --site-dir _site
         

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Tim
+Copyright (c) 2025-2026 Tim Walsh
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # cu - ClickUp CLI
 
 [![CI](https://github.com/timimsms/cu/actions/workflows/ci.yml/badge.svg)](https://github.com/timimsms/cu/actions/workflows/ci.yml)
+[![Release](https://img.shields.io/github/v/release/timimsms/cu)](https://github.com/timimsms/cu/releases/latest)
 [![Documentation](https://img.shields.io/badge/docs-timimsms.github.io%2Fcu-blue)](https://timimsms.github.io/cu/)
 
 > **Note**: `cu` is an unofficial, community-maintained project and is not affiliated with or endorsed by ClickUp.

--- a/docs/site/changelog.md
+++ b/docs/site/changelog.md
@@ -1,0 +1,53 @@
+# Changelog
+
+Release notes for `cu`. This page is regenerated from [GitHub Releases](https://github.com/timimsms/cu/releases) on every documentation deploy.
+
+## [v0.1.0](https://github.com/timimsms/cu/releases/tag/v0.1.0) — 2026-07-15
+
+### New Features
+* feat: Add authentication, output formatting, and error handling
+* feat: Complete API client foundation with ClickUp SDK integration
+* feat: Implement Phase 2 core features - basic commands
+* feat: Initialize project structure with Cobra CLI framework
+* feat: add API passthrough command for direct API access
+* feat: add GoReleaser config and release workflow for distribution
+* feat: add MkDocs documentation site setup
+* feat: add advanced filtering and sorting to task list
+* feat: add cache management commands
+* feat: add command documentation generation
+* feat: add comprehensive task search functionality
+* feat: add documentation build test to CI workflow
+* feat: add interactive mode for task management
+* feat: add project-specific configuration support
+* feat: add task close and reopen commands
+* feat: add task comment management commands
+* feat: add task export functionality with multiple formats
+* feat: implement bulk operations for task management
+* feat: implement task create command
+* feat: implement task update command
+* feat: implement task view command
+* feat: implement user ID lookup for assignee management
+* feat: register new commands in root command structure
+### Bug Fixes
+* fix: Add permissions for SARIF upload in security scan
+* fix: Resolve CI/CD pipeline failures
+* fix: Resolve gosec security scan failure
+* fix: correct mkdocstrings-go package installation in deploy-docs workflow
+* fix: improve CI script formatting checks
+* fix: make cache tests platform-agnostic
+* fix: remove mkdocstrings dependencies from deploy-docs workflow
+* fix: remove mkdocstrings plugin from documentation configuration
+* fix: remove unused resolveComment variable
+* fix: resolve CI linting issues
+* fix: resolve G304 security vulnerability in cache system
+* fix: resolve code formatting issues
+* fix: resolve gosec G304 security vulnerability in export command
+* fix: resolve gosec G304 security warnings in cache.go
+* fix: resolve gosec security vulnerabilities in project config
+* fix: resolve linting issues
+* fix: resolve linting issues in API command
+* fix: resolve staticcheck linting issues
+* fix: skip permission-bit and symlink tests on Windows
+* fix: update documentation navigation to match generated command files
+* fix: use more restrictive permissions for directory creation
+

--- a/docs/site/index.md
+++ b/docs/site/index.md
@@ -1,5 +1,7 @@
 # cu - ClickUp CLI
 
+[![Release](https://img.shields.io/github/v/release/timimsms/cu)](https://github.com/timimsms/cu/releases/latest)
+
 > **Note**: `cu` is an unofficial, community-maintained project and is not affiliated with or endorsed by ClickUp.
 
 A GitHub CLI-inspired command-line interface for ClickUp.
@@ -64,6 +66,7 @@ cu task create
 
 ## Next Steps
 
+- [Changelog](changelog.md) - What's new in each release
 - [Authentication & Security](authentication.md) - Create a token and connect `cu` to ClickUp
 - [Command Reference](commands/cu.md) - Explore all available commands
 - [Task Management](commands/cu_task.md) - Learn how to manage tasks

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -33,6 +33,7 @@ theme:
 nav:
   - Home: index.md
   - Authentication & Security: authentication.md
+  - Changelog: changelog.md
   - Commands:
     - cu: commands/cu.md
     - Authentication:


### PR DESCRIPTION
## Summary

- **Changelog page** on the docs site, auto-regenerated from GitHub Releases on every deploy — the deploy workflow now also triggers on `release: published`, so the page refreshes the moment a release ships with zero manual edits. Bullets are cleaned (commit SHAs and author emails stripped, per-release install footers trimmed). A committed snapshot keeps `mkdocs build --strict` green in CI and locally.
- **Release badges** on README and the docs homepage (shields.io, auto-updates per release).
- **LICENSE** attribution updated to `Copyright (c) 2025-2026 Tim Walsh`.

## Test plan

- [x] `mkdocs build --strict` passes locally with the new page and nav entry
- [x] Generation pipeline (gh api + jq + sed) run locally — output verified free of SHAs/emails
- [x] Both edited workflows/YAML parse
- [ ] CI green
- [ ] Post-merge: Deploy Documentation run regenerates and publishes /changelog/

🤖 Generated with [Claude Code](https://claude.com/claude-code)